### PR TITLE
Setup for Dokken based testing

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,30 @@
+---
+driver:
+  name: dokken
+  chef_version: latest
+  pid_one_command: /usr/lib/systemd/systemd
+  privileged: true
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  intermediate_instructions:
+    - VOLUME /var/lib/docker
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      hostname: default
+        
+suites:
+  - name: default
+    run_list:
+      - recipe[kube_text::default]

--- a/test/cookbooks/kube_test/recipes/default.rb
+++ b/test/cookbooks/kube_test/recipes/default.rb
@@ -43,6 +43,10 @@ if platform_family?('debian')
   apt_update
 end
 
+if platform_family?('rhel')
+  package 'e2fsprogs'
+end
+
 docker_service 'default' do
   iptables false
   ip_masq false


### PR DESCRIPTION
Point KITCHEN_YAML to .kitchen.dokken.yml in order to use Dokken driver for testing.